### PR TITLE
fixed background colors for vertical file tabs

### DIFF
--- a/JFlepp.VS.Theme.DarkYellow/CustomTheme.vstheme
+++ b/JFlepp.VS.Theme.DarkYellow/CustomTheme.vstheme
@@ -4113,6 +4113,15 @@
       <Color Name="ComboBoxFocusBox">
         <Background Type="CT_RAW" Source="FFFFFFFF" />
       </Color>
+      <Color Name="FileTabGroupTitleBackground">
+        <Background Type="CT_RAW" Source="FF3E3E40" />
+      </Color>
+      <Color Name="FileTabActiveGroupTitleBackground">
+        <Background Type="CT_RAW" Source="FF3E3E40" />
+      </Color>
+      <Color Name="FileTabActiveGroupBackground">
+        <Background Type="CT_RAW" Source="FF3E3E40" />
+      </Color>
     </Category>
     <Category Name="Find" GUID="{4370282e-987e-4ac4-ad14-5ffed2ad1e14}">
       <Color Name="DropDownMenuMouseDown">


### PR DESCRIPTION
In VisualStudio 16.5.2, when you enable the new vertical tab layout (i.e. "tabs" in a column on the left or right of the editor window) the tabs show with white text on almost white (default) background.

This change sets the background to the same dark color as most of the rest of the UI.